### PR TITLE
Implement JWT authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'com.auth0:java-jwt:4.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/controller/AuthController.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/controller/AuthController.java
@@ -1,0 +1,37 @@
+package ch.datamanager.carnivor.dndbackend.controller;
+
+import ch.datamanager.carnivor.dndbackend.service.AuthService;
+import javax.annotation.Resource;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+  @Resource
+  private AuthService authService;
+
+  @PostMapping("/sign-in")
+  public String signIn(@RequestBody AuthRequest request) {
+    return authService.signIn(request.getUsername(), request.getPassword());
+  }
+
+  @PostMapping("/sign-up")
+  public String signUp(@RequestBody AuthRequest request) {
+    return authService.signUp(request.getUsername(), request.getPassword());
+  }
+
+  @Data
+  @FieldDefaults(level = AccessLevel.PRIVATE)
+  public static class AuthRequest {
+    String username;
+    String password;
+  }
+
+}

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/controller/MainController.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/controller/MainController.java
@@ -1,6 +1,5 @@
 package ch.datamanager.carnivor.dndbackend.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/entities/UserRepository.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/entities/UserRepository.java
@@ -10,12 +10,13 @@ import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
 
-
-
     @Override
     Optional<User> findById(UUID uuid);
 
     List<User> findAll();
 
     Optional<User> findByUsername(String s);
+
+    boolean existsByUsername(String username);
+
 }

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/init/DataLoader.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/init/DataLoader.java
@@ -2,41 +2,46 @@ package ch.datamanager.carnivor.dndbackend.init;
 
 import ch.datamanager.carnivor.dndbackend.entities.User;
 import ch.datamanager.carnivor.dndbackend.entities.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.ApplicationRunner;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-
 @Component
-public class DataLoader implements ApplicationRunner {
+@RequiredArgsConstructor
+public class DataLoader {
 
-    private UserRepository userRepository;
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
 
-    @Autowired
-    public DataLoader(UserRepository userRepository) {
-        this.userRepository = userRepository;
+  @EventListener(ApplicationReadyEvent.class)
+  public void setup() {
+    if (userRepository.count() != 0) {
+      // database already initialized -- skip
+      return;
     }
-    private Iterable<User> users = Arrays.asList(new User[]{
-            User.builder()
-                    .username("admin")
-                    .passwd("nimda")
-                    .mail("admin@dndnav.com")
-                    .build(),
-            User.builder()
-                    .username("none")
-                    .passwd("")
-                    .mail("none@dndnav.com")
-                    .build(),
-            User.builder()
-                    .username("user1")
-                    .passwd("pass1")
-                    .mail("user1@dndnav.com")
-                    .build()
-    });
 
-    public void run(ApplicationArguments args) {
-        userRepository.saveAll(users);
-    }
+    var users = List.of(
+        User.builder()
+            .username("admin")
+            .passwd(passwordEncoder.encode("nimda"))
+            .mail("admin@dndnav.com")
+            .build(),
+        User.builder()
+            .username("none")
+            .passwd(passwordEncoder.encode(""))
+            .mail("none@dndnav.com")
+            .build(),
+        User.builder()
+            .username("user1")
+            .passwd(passwordEncoder.encode("pass1"))
+            .mail("user1@dndnav.com")
+            .build()
+    );
+
+    userRepository.saveAll(users);
+  }
+
 }

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/security/MyUserDetailsService.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/security/MyUserDetailsService.java
@@ -1,12 +1,13 @@
 package ch.datamanager.carnivor.dndbackend.security;
 
-import ch.datamanager.carnivor.dndbackend.entities.User;
 import ch.datamanager.carnivor.dndbackend.entities.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
 
+@Component
 public class MyUserDetailsService implements UserDetailsService {
 
     @Autowired
@@ -14,10 +15,8 @@ public class MyUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) {
-        User user = userRepository.findByUsername(username).get();
-        if (user == null) {
-            throw new UsernameNotFoundException(username);
-        }
-        return new MyUserPrincipal(user);
+        return userRepository.findByUsername(username)
+            .map(MyUserPrincipal::new)
+            .orElseThrow(() -> new UsernameNotFoundException(username));
     }
 }

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/security/SecurityConfig.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/security/SecurityConfig.java
@@ -1,12 +1,22 @@
 package ch.datamanager.carnivor.dndbackend.security;
 
+import ch.datamanager.carnivor.dndbackend.security.jwt.JwtTokenConfigurer;
+import ch.datamanager.carnivor.dndbackend.security.jwt.JwtTokenFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -16,50 +26,54 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
 
-@EnableWebSecurity
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final JwtTokenConfigurer jwtTokenConfigurer;
 
-    @Bean
-    public UserDetailsService userDetailsService(){
-        return new MyUserDetailsService();
-    }
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder(12);
+  }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return NoOpPasswordEncoder.getInstance();
-    }
+  @Bean
+  public AuthenticationManager authenticationManagerBean(AuthenticationConfiguration configuration)
+      throws Exception {
 
-    @Bean
-    CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList(
-                "https://localhost*",
-                "http://localhost*"
-        ));
-        configuration.setAllowedMethods(Arrays.asList("GET","POST"));
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
+    return configuration.getAuthenticationManager();
+  }
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeHttpRequests((requests) -> requests
-                        .antMatchers("/", "/home").permitAll()
-                        .antMatchers("/*").permitAll()
-                        .anyRequest().authenticated()
-                )
-                .formLogin((form) -> form
-                        .loginProcessingUrl("/login")
-                        .permitAll()
-                )
-                .logout(LogoutConfigurer::permitAll);
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf().disable()
+        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
-        return http.build();
-    }
+        // remember: JWT token whitelisted routes are configured in application.properties
+        .and().authorizeHttpRequests(requests -> requests
+            .antMatchers("/", "/home").permitAll()
+            .antMatchers("/auth/*").permitAll()
+            .anyRequest().authenticated()
+        )
+        .formLogin(AbstractHttpConfigurer::disable)
+        .apply(jwtTokenConfigurer);
 
+    return http.build();
+  }
+
+  @Bean
+  CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOrigins(Arrays.asList(
+        "https://localhost*",
+        "http://localhost*"
+    ));
+    configuration.setAllowedMethods(Arrays.asList("GET","POST"));
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+  }
 
 }

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/security/jwt/JwtTokenConfigurer.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/security/jwt/JwtTokenConfigurer.java
@@ -1,0 +1,24 @@
+package ch.datamanager.carnivor.dndbackend.security.jwt;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenConfigurer extends
+    SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+  private final JwtTokenFilter jwtTokenFilter;
+
+  @Override
+  public void configure(HttpSecurity http) throws Exception {
+    http.addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);
+  }
+
+}

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/security/jwt/JwtTokenFilter.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/security/jwt/JwtTokenFilter.java
@@ -1,0 +1,60 @@
+package ch.datamanager.carnivor.dndbackend.security.jwt;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+  @Value("${jwt.allowed-endpoints}")
+  private Set<String> allowedEndpoints;
+
+  private final JwtUtil jwtUtil;
+
+  private final UserDetailsService userDetailsService;
+
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse, FilterChain filterChain)
+      throws ServletException, IOException {
+    Optional<DecodedJWT> potentialDecodedToken = jwtUtil.decode(httpServletRequest);
+
+    if (potentialDecodedToken.isPresent()) {
+      DecodedJWT decodedJWT = potentialDecodedToken.get();
+      authenticate(decodedJWT);
+    } else if (!allowedEndpoints.contains(httpServletRequest.getRequestURI())) {
+      SecurityContextHolder.clearContext();
+      httpServletResponse.sendError(HttpStatus.UNAUTHORIZED.value(), "Token validation failed");
+      return;
+    }
+
+    filterChain.doFilter(httpServletRequest, httpServletResponse);
+  }
+
+  private void authenticate(DecodedJWT token) {
+    UserDetails userDetails = userDetailsService.loadUserByUsername(token.getSubject());
+    Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails,
+        Strings.EMPTY, userDetails.getAuthorities());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+}

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/security/jwt/JwtUtil.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/security/jwt/JwtUtil.java
@@ -1,0 +1,70 @@
+package ch.datamanager.carnivor.dndbackend.security.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+  private static final String AUTHORIZATION_HEADER = HttpHeaders.AUTHORIZATION;
+
+  @Value("${jwt.secret}")
+  private String jwtSecret;
+
+  @Value("${jwt.validity}")
+  private Period jwtValidity;
+
+  public static Optional<String> extractTokenFromRequest(HttpServletRequest request) {
+    try {
+      return Optional.ofNullable(request.getHeader(AUTHORIZATION_HEADER))
+          .filter(header -> header.startsWith("Bearer "))
+          .map(header -> header.substring(7)) // "Bearer " including the space
+          .filter(token -> !token.isBlank());
+    } catch (IndexOutOfBoundsException e) {
+      return Optional.empty();
+    }
+  }
+
+  public String issueToken(String username) {
+    ZonedDateTime expiryDate = ZonedDateTime.now().plus(jwtValidity);
+    return JWT.create()
+        .withSubject(username)
+        .withExpiresAt(Date.from(expiryDate.toInstant()))
+        .sign(Algorithm.HMAC256(jwtSecret.getBytes()));
+  }
+
+  public Optional<DecodedJWT> decode(HttpServletRequest request) {
+    return extractTokenFromRequest(request)
+        .flatMap(this::decode);
+  }
+
+  public Optional<DecodedJWT> decode(String token) {
+    if (Objects.isNull(token) || token.isBlank()) {
+      return Optional.empty();
+    }
+
+    try {
+      DecodedJWT decoded = JWT.require(Algorithm.HMAC256(jwtSecret.getBytes()))
+          .build()
+          .verify(token);
+      return Optional.ofNullable(decoded);
+    } catch (JWTVerificationException e) {
+      // todo: logging, or proper exception handling
+      return Optional.empty();
+    }
+
+  }
+}

--- a/src/main/java/ch/datamanager/carnivor/dndbackend/service/AuthService.java
+++ b/src/main/java/ch/datamanager/carnivor/dndbackend/service/AuthService.java
@@ -1,0 +1,50 @@
+package ch.datamanager.carnivor.dndbackend.service;
+
+import ch.datamanager.carnivor.dndbackend.entities.User;
+import ch.datamanager.carnivor.dndbackend.entities.UserRepository;
+import ch.datamanager.carnivor.dndbackend.security.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final JwtUtil jwtUtil;
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final AuthenticationManager authenticationManager;
+
+  public String signIn(String username, String password) {
+    try {
+      authenticationManager.authenticate(
+          new UsernamePasswordAuthenticationToken(username, password));
+      return jwtUtil.issueToken(username);
+    } catch (AuthenticationException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "Invalid username/password supplied");
+    }
+  }
+
+  public String signUp(String username, String password) {
+    if (userRepository.existsByUsername(username)) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, "Username already in use");
+    }
+
+    User user = User.builder()
+        .username(username)
+        .passwd(passwordEncoder.encode(password))
+        .build();
+
+    userRepository.save(user);
+
+    return jwtUtil.issueToken(username);
+  }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,9 @@ spring.datasource.url=jdbc:mariadb://localhost:3306/dnd
 spring.datasource.username=root
 spring.datasource.password=toor
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=update
+
+jwt.secret=changeme
+jwt.validity=1D
+
+jwt.allowed-endpoints=/auth/sign-in,/auth/sign-up


### PR DESCRIPTION
Implemented JWT authentication, heavily inspired by [this project](https://github.com/murraco/spring-boot-jwt/tree/master/src/main/java/murraco/security)

- JwtUitl implements logic for issuing and decoding/verifying tokens
- Requests are filtered using JwtTokenFilter. Any requests without a valid token will be rejected (unauthorized).
- Certain URIs can be whitelisted using the spring config (Tokens won't be checked).
- Passwords are now bcrypt encoded. I recommend no longer re-creating the database on startup (ddl-auto).
- JWT HMAC secret and validity period can be configured.

Sample spring config:
```properties
# Maria DB
spring.datasource.url=jdbc:mariadb://localhost:3306/dnd
spring.datasource.username=root
spring.datasource.password=toor
spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
spring.jpa.hibernate.ddl-auto=update

jwt.secret=changeme
jwt.validity=1D

jwt.allowed-endpoints=/auth/sign-in,/auth/sign-up
```